### PR TITLE
Fix Python viewer calling do_activate twice

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -7,17 +7,16 @@ class MyApplication(Gtk.Application):
         Gtk.Application.__init__(self,
                                  application_id="org.lokdocviewer.pyviewer",
                                  flags=Gio.ApplicationFlags.FLAGS_NONE)
-        self.connect("activate", self.do_activate)
 
-    def do_activate(self, app):
-        win = Gtk.ApplicationWindow(title="LOK Document Viewer", default_height=600, default_width=800)
+    def do_activate(self):
+        win = Gtk.ApplicationWindow(application=self,
+                                    title="LOK Document Viewer",
+                                    default_height=600, default_width=800)
         view = LOKDocView.View.new(None, None)
 
         sw = Gtk.ScrolledWindow(hexpand=True, vexpand=True)
         win.add(sw)
         sw.add(view)
-
-        app.add_window(win)
 
         view.open_document("/opt/orig.odt", "{}", None, None, None)
         win.show_all()


### PR DESCRIPTION
do_activate() is a Python override for GApplication activate().